### PR TITLE
Fix requirements call

### DIFF
--- a/src/YouTubeField.php
+++ b/src/YouTubeField.php
@@ -19,8 +19,8 @@ class YouTubeField extends TextField
 
     public function Field($properties = [])
     {
-        Requirements::css('toastnz/youtubefield:client/css/YouTubeField.css');
-        Requirements::javascript('toastnz/youtubefield:client/js/YouTubeField.js');
+        Requirements::css('sunnysideup/youtubefield:client/css/YouTubeField.css');
+        Requirements::javascript('sunnysideup/youtubefield:client/js/YouTubeField.js');
 
         if ($api_key = $this->config()->get('api_key')) {
             $this->setAttribute('data-apikey', $api_key);


### PR DESCRIPTION
Requirements in the admin field is calling the old module name, not the current `sunnysideup/silverstripe-youtubefield`